### PR TITLE
Fix instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ and then passed to some dangerous function like `system`".
 - [Install Yara](https://yara.readthedocs.io/en/stable/gettingstarted.html#compiling-and-installing-yara).  
 This is also possible via some Linux package managers:  
   - Debian: `sudo apt-get install yara`  
-  - Red Hat: `yum install yara` (requires the [EPEL repository](https://fedoraproject.org/wiki/EPEL))
+  - Red Hat: `yum install yara-devel` (requires the [EPEL repository](https://fedoraproject.org/wiki/EPEL))
 
 You can also compile it from source:
 
@@ -90,7 +90,7 @@ Usage phpmalwarefinder [-cfhtvl] <file|folder> ...
 Or if you prefer to use `yara`:
 
 ```
-$ yara -r ./php.yar /var/www
+$ yara -r data/php.yar /var/www
 ```
 
 Please keep in mind that you should use at least YARA 3.4 because we're using


### PR DESCRIPTION
On Red Hat-based distros, the necessary header files are packaged separately as `yara-devel`. Installing that will pull in `yara` as dependency.